### PR TITLE
Basic dummy course access group backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ different permissions to groups.
 
 
 Overview
-------------------------------
+--------
 
 This is a plugin for the Open edX Platform that provides the Course Access
 Group functionality. It can be installed via pip with minimal configuration to
@@ -30,6 +30,30 @@ Documentation
 -------------
 
 The full documentation is at https://course-access-groups.readthedocs.org.
+
+Quickstart Instructions
+-----------------------
+
+Install this plugin via ``pip``. Then configure your Ansibe
+``server-vars.yml`` with the following:
+
+.. code:: yaml
+
+    ACCESS_CONTROL_BACKENDS:
+        course.enroll:
+            NAME: course_access_groups.acl_backends:dummy_backend
+        course.load:
+            NAME: course_access_groups.acl_backends:dummy_backend
+        course.see_in_catalog:
+            NAME: course_access_groups.acl_backends:dummy_backend
+
+.. _Access Control Backends pull request: https://github.com/appsembler/edx-platform/pull/491
+
+This plugin requires some changes on the Open edX Platform which can be found
+in the `Access Control Backends pull request`_.
+
+The intention is to make this plugin work in the Open edX Platform out of the
+box but today, that's not the case the pull request should be cherry-picked.
 
 License
 -------

--- a/course_access_groups/acl_backends.py
+++ b/course_access_groups/acl_backends.py
@@ -1,0 +1,19 @@
+"""
+Access Control backends to implement the Course Access Groups.
+"""
+import six
+
+
+def dummy_backend(user, resource, default_has_access, options):  # pylint: disable=unused-argument
+    """
+    Access control backend to prevent users from loading the course `course-v1:Red+Red+Red2020`.
+
+    Users with emails `@example.com` and `@appsembler.com` are being prevented, as long as they're logged in.
+    """
+    if six.text_type(resource.id) == 'course-v1:Red+Red+Red2020':
+        if user.is_authenticated and (
+            user.email.endswith('@example.com') or user.email.endswith('@appsembler.com')
+        ):
+            return False
+
+    return default_has_access

--- a/manage.py
+++ b/manage.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django  # pylint: disable=unused-import, wrong-import-position
+            import django  # pylint: disable=unused-import
         except ImportError:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# pylint: disable=open-builtin,native-string
 """
 Package metadata for course_access_groups.
 """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,8 +6,13 @@ Tests for the `course-access-groups` models module.
 
 from __future__ import absolute_import, unicode_literals
 
+from course_access_groups import acl_backends, models, urls
+
 
 def test_fake():
     """
     Just a fake unit test case.
     """
+    assert acl_backends
+    assert models
+    assert urls


### PR DESCRIPTION
A dummy access control backend to prevent users from `@example.com` and `@appsembler.com` from loading the course `course-v1:Red+Red+Red2020`.