### PR TITLE
CAG access control backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,10 @@ language: python
 
 python:
   - 2.7
-  - 3.6
 
 env:
-  - TOXENV=django111
-  - TOXENV=django20
-
-matrix:
-  exclude:
-    - python: 2.7
-      env: TOXENV=django20
-  include:
-    - python: 3.6
-      env: TOXENV=quality
-    - python: 3.6
-      env: TOXENV=docs
-    - python: 3.6
-      env: TOXENV=pii_check
+  - TOXENV=py27-django111
+  - TOXENV=docs
 
 cache:
   - pip

--- a/course_access_groups/acl_backends.py
+++ b/course_access_groups/acl_backends.py
@@ -1,19 +1,72 @@
 """
 Access Control backends to implement the Course Access Groups.
 """
-import six
+
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from organizations.api import get_course_organizations
+from organizations.models import UserOrganizationMapping
+from course_access_groups.models import (
+    CourseAccessGroup,
+    GroupCourse,
+    Membership,
+)
 
 
-def dummy_backend(user, resource, default_has_access, options):  # pylint: disable=unused-argument
+def is_organization_staff(user, course):
     """
-    Access control backend to prevent users from loading the course `course-v1:Red+Red+Red2020`.
+    Helper to check if the user is organization staff.
 
-    Users with emails `@example.com` and `@appsembler.com` are being prevented, as long as they're logged in.
+    TODO: Handle single-site setups in which organization is not important
     """
-    if six.text_type(resource.id) == 'course-v1:Red+Red+Red2020':
-        if user.is_authenticated and (
-            user.email.endswith('@example.com') or user.email.endswith('@appsembler.com')
-        ):
-            return False
+    # TODO: What if a course has two orgs? data leak I guess?
+    organizations = get_course_organizations(course.id)
+    if not len(organizations):
+        return False
 
-    return default_has_access
+    return UserOrganizationMapping.objects.filter(
+        user=user,
+        organization_id__in=[org['id'] for org in organizations],
+        is_active=True,
+        is_amc_admin=True,
+    ).exists()
+
+
+def is_feature_enabled():
+    """
+    Helper to check Site Configuration for ENABLE_COURSE_ACCESS_GROUPS.
+    :return:
+    """
+    return bool(configuration_helpers.get_value('ENABLE_COURSE_ACCESS_GROUPS', default=False))
+
+
+def default_backend(user, resource, default_has_access, options):  # pylint: disable=unused-argument
+    """
+    The Access Control Backend to plug the Course Access Groups feature in Open edX.
+    """
+    if not is_feature_enabled():
+        # Plugin is turned off, maintain the platform's default behaviour.
+        return default_has_access
+
+    if not default_has_access:
+        # Ensures this backend won't leak resources by mistake.
+        return False
+
+    if user.is_staff or user.is_superuser:
+        return default_has_access
+
+    if is_organization_staff(user, resource):
+        return default_has_access
+
+    user_groups = CourseAccessGroup.objects.filter(
+        pk__in=Membership.objects.filter(
+            user=user,
+        ).values('group_id'),
+    )
+
+    return GroupCourse.objects.filter(
+        course=resource,
+        group__in=user_groups,
+    ).exists()
+
+
+__all__ = ['default_backend']

--- a/course_access_groups/acl_backends.py
+++ b/course_access_groups/acl_backends.py
@@ -20,7 +20,7 @@ def is_organization_staff(user, course):
     """
     # TODO: What if a course has two orgs? data leak I guess?
     organizations = get_course_organizations(course.id)
-    if not len(organizations):
+    if not organizations:
         return False
 
     return UserOrganizationMapping.objects.filter(

--- a/course_access_groups/acl_backends.py
+++ b/course_access_groups/acl_backends.py
@@ -1,10 +1,13 @@
+# -*- coding: utf-8 -*-
 """
 Access Control backends to implement the Course Access Groups.
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from organizations.api import get_course_organizations
-from organizations.models import UserOrganizationMapping
+from organizations.models import OrganizationCourse, UserOrganizationMapping
+import six
 from course_access_groups.models import (
     CourseAccessGroup,
     GroupCourse,
@@ -16,16 +19,26 @@ def is_organization_staff(user, course):
     """
     Helper to check if the user is organization staff.
 
+    :param user: User to check access against.
+    :param course: The Course or CourseOverview object to check access for.
+
+    :return: bool
+
     TODO: Handle single-site setups in which organization is not important
+    TODO: What if a course has two orgs? data leak I guess?
     """
-    # TODO: What if a course has two orgs? data leak I guess?
-    organizations = get_course_organizations(course.id)
-    if not organizations:
+    if not user.is_active:
         return False
+
+    # Same as organization.api.get_course_organizations
+    course_org_ids = OrganizationCourse.objects.filter(
+        course_id=six.text_type(course.id),
+        active=True
+    ).values('organization_id')
 
     return UserOrganizationMapping.objects.filter(
         user=user,
-        organization_id__in=[org['id'] for org in organizations],
+        organization_id__in=course_org_ids,
         is_active=True,
         is_amc_admin=True,
     ).exists()
@@ -34,21 +47,31 @@ def is_organization_staff(user, course):
 def is_feature_enabled():
     """
     Helper to check Site Configuration for ENABLE_COURSE_ACCESS_GROUPS.
-    :return:
+
+    :return: bool
     """
     return bool(configuration_helpers.get_value('ENABLE_COURSE_ACCESS_GROUPS', default=False))
 
 
-def default_backend(user, resource, default_has_access, options):  # pylint: disable=unused-argument
+def user_has_access(user, resource, default_has_access, options):  # pylint: disable=unused-argument
     """
     The Access Control Backend to plug the Course Access Groups feature in Open edX.
+
+    :param user: User to check access against.
+    :param resource: Usually a Course or CourseOverview object to check access for.
+    :param default_has_access: The platform default access check, useful as a callback.
+    :param options: Extra options, nothing in particular here.
+    :return: bool: whether the user is granted access or no.
     """
     if not is_feature_enabled():
         # Plugin is turned off, maintain the platform's default behaviour.
         return default_has_access
 
     if not default_has_access:
-        # Ensures this backend won't leak resources by mistake.
+        # Only permit resources that both Open edX [and] CAG rules allow.
+        # i.e. Course Access Groups should not leak resources that Open edX don't want to permit.
+        # e.g. In case the `course.is_deleted` feature is enabled, Open edX would prevent course access regardless
+        # of the permission. It's good to have the CAG module future proof in case of such changes.
         return False
 
     if user.is_staff or user.is_superuser:
@@ -69,4 +92,4 @@ def default_backend(user, resource, default_has_access, options):  # pylint: dis
     ).exists()
 
 
-__all__ = ['default_backend']
+__all__ = ['user_has_access']

--- a/mocks/openedx/core/djangoapps/site_configuration/__init__.py
+++ b/mocks/openedx/core/djangoapps/site_configuration/__init__.py
@@ -1,0 +1,3 @@
+"""
+Mock Site Configuration module.
+"""

--- a/mocks/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/mocks/openedx/core/djangoapps/site_configuration/helpers.py
@@ -1,0 +1,16 @@
+"""
+Mock Site Configuration Helpers.
+
+Use `test_utils.patch_site_configs` to patch the site configuration.
+"""
+
+MOCK_SITE_CONFIG_VALUES = {
+    'ENABLE_COURSE_ACCESS_GROUPS': True,
+}
+
+
+def get_value(val_name, default=None, **kwargs):  # pylint: disable=unused-argument
+    """
+    Mock openedx.core.djangoapps.site_configuration.helpers.get_value.
+    """
+    return MOCK_SITE_CONFIG_VALUES.get(val_name, default)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,13 +10,13 @@ certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 django-model-utils==3.0.0
 django-waffle==0.19.0     # via edx-django-utils, edx-drf-extensions
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework-oauth==1.1.0
 djangorestframework==3.6.4  # via edx-drf-extensions, rest-condition
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==2.0.4   # via edx-drf-extensions
-edx-drf-extensions==2.4.5
+edx-drf-extensions==2.4.6
 edx-opaque-keys==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4
 enum34==1.1.6             # via fs
@@ -25,7 +25,7 @@ future==0.18.2            # via backports.os, pyjwkest
 idna==2.8                 # via requests
 lxml==4.5.0               # via xblock
 markupsafe==1.1.1         # via xblock
-newrelic==5.4.1.134       # via edx-django-utils
+newrelic==5.6.0.135       # via edx-django-utils
 pbr==5.4.4                # via stevedore
 pillow==6.2.2
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -41,7 +41,7 @@ rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.4   # via edx-drf-extensions
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 six==1.14.0               # via django-waffle, edx-drf-extensions, edx-opaque-keys, fs, pyjwkest, python-dateutil, stevedore, xblock
-stevedore==1.31.0         # via edx-opaque-keys
+stevedore==1.32.0         # via edx-opaque-keys
 typing==3.7.4.1           # via fs
 urllib3==1.25.8           # via requests
 web-fragments==0.3.1      # via xblock

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,17 +21,17 @@ codecov==2.0.15
 configparser==4.0.2
 contextlib2==0.6.0.post1
 coverage==5.0.3
-diff-cover==2.5.2
+diff-cover==2.6.0
 distlib==0.3.0
 django-model-utils==3.0.0
 django-waffle==0.19.0
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0
 djangorestframework-oauth==1.1.0
 djangorestframework==3.6.4
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==2.0.4
-edx-drf-extensions==2.4.5
+edx-drf-extensions==2.4.6
 edx-i18n-tools==0.5.0
 edx-lint==0.5.5
 edx-opaque-keys==0.4.4
@@ -46,6 +46,7 @@ future==0.18.2
 futures==3.3.0 ; python_version == "2.7"
 idna==2.8
 importlib-metadata==1.5.0
+importlib-resources==1.0.2
 inflect==3.0.2            # via jinja2-pluralize
 ipaddress==1.0.23
 isort==4.3.21
@@ -55,8 +56,9 @@ lazy-object-proxy==1.4.3
 lxml==4.5.0
 markupsafe==1.1.1
 mccabe==0.6.1
+mock==3.0.5
 more-itertools==5.0.0
-newrelic==5.4.1.134
+newrelic==5.6.0.135
 packaging==20.1
 path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.5
@@ -94,14 +96,14 @@ shortuuid==0.5.0
 singledispatch==3.4.0.3
 six==1.14.0
 snowballstemmer==2.0.0
-stevedore==1.31.0
+stevedore==1.32.0
 text-unidecode==1.3
 toml==0.10.0
 tox-battery==0.5.2
-tox==3.14.3
+tox==3.14.4
 typing==3.7.4.1
 urllib3==1.25.8
-virtualenv==16.7.9
+virtualenv==20.0.3
 wcwidth==0.1.8
 web-fragments==0.3.1
 webob==1.8.6

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,7 +20,7 @@ contextlib2==0.6.0.post1
 coverage==5.0.3
 django-model-utils==3.0.0
 django-waffle==0.19.0
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0
 djangorestframework-oauth==1.1.0
 djangorestframework==3.6.4
@@ -28,7 +28,7 @@ doc8==0.8.0
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==2.0.4
-edx-drf-extensions==2.4.5
+edx-drf-extensions==2.4.6
 edx-opaque-keys==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4
 edx-sphinx-theme==1.5.0
@@ -45,8 +45,9 @@ ipaddress==1.0.23
 jinja2==2.11.1
 lxml==4.5.0
 markupsafe==1.1.1
+mock==3.0.5
 more-itertools==5.0.0
-newrelic==5.4.1.134
+newrelic==5.6.0.135
 packaging==20.1
 pathlib2==2.3.5
 pbr==5.4.4
@@ -78,7 +79,7 @@ six==1.14.0
 snowballstemmer==2.0.0    # via sphinx
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
-stevedore==1.31.0
+stevedore==1.32.0
 text-unidecode==1.3
 typing==3.7.4.1
 urllib3==1.25.8

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -23,13 +23,13 @@ coverage==5.0.3
 distlib==0.3.0            # via caniusepython3
 django-model-utils==3.0.0
 django-waffle==0.19.0
-django==1.11.27
+django==1.11.28
 djangorestframework-jwt==1.11.0
 djangorestframework-oauth==1.1.0
 djangorestframework==3.6.4
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==2.0.4
-edx-drf-extensions==2.4.5
+edx-drf-extensions==2.4.6
 edx-lint==0.5.5
 edx-opaque-keys==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4
@@ -49,8 +49,9 @@ lazy-object-proxy==1.4.3  # via astroid
 lxml==4.5.0
 markupsafe==1.1.1
 mccabe==0.6.1             # via pylint
+mock==3.0.5
 more-itertools==5.0.0
-newrelic==5.4.1.134
+newrelic==5.6.0.135
 packaging==20.1
 pathlib2==2.3.5
 pbr==5.4.4
@@ -84,7 +85,7 @@ shortuuid==0.5.0
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.14.0
 snowballstemmer==2.0.0    # via pydocstyle
-stevedore==1.31.0
+stevedore==1.32.0
 text-unidecode==1.3
 typing==3.7.4.1
 urllib3==1.25.8

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -8,3 +8,4 @@ pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 code-annotations          # provides commands used by the pii_check make target.
 factory_boy==2.8.1        # Django models factory for tests
+mock                      # Mocks for testing

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -22,14 +22,14 @@ djangorestframework-oauth==1.1.0
 djangorestframework==3.6.4
 edx-django-oauth2-provider==1.3.5
 edx-django-utils==2.0.4
-edx-drf-extensions==2.4.5
+edx-drf-extensions==2.4.6
 edx-opaque-keys==0.4.4
 git+https://github.com/appsembler/edx-organizations.git@0.4.12-appsembler4
 enum34==1.1.6
 factory_boy==2.8.1
 faker==3.0.1              # via factory-boy
 fs==2.4.11
-funcsigs==1.0.2           # via pytest
+funcsigs==1.0.2           # via mock, pytest
 future==0.18.2
 idna==2.8
 importlib-metadata==1.5.0  # via pluggy, pytest
@@ -37,8 +37,9 @@ ipaddress==1.0.23         # via faker
 jinja2==2.11.1            # via code-annotations
 lxml==4.5.0
 markupsafe==1.1.1
+mock==3.0.5
 more-itertools==5.0.0     # via pytest
-newrelic==5.4.1.134
+newrelic==5.6.0.135
 packaging==20.1           # via pytest
 pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
 pbr==5.4.4
@@ -64,7 +65,7 @@ scandir==1.10.0           # via pathlib2
 semantic-version==2.8.4
 shortuuid==0.5.0
 six==1.14.0
-stevedore==1.31.0
+stevedore==1.32.0
 text-unidecode==1.3       # via faker, python-slugify
 typing==3.7.4.1
 urllib3==1.25.8

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,26 +4,30 @@
 #
 #    make upgrade
 #
+appdirs==1.4.3            # via virtualenv
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
+contextlib2==0.6.0.post1  # via importlib-metadata, virtualenv, zipp
 coverage==5.0.3           # via codecov
-filelock==3.0.12          # via tox
+distlib==0.3.0            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
 idna==2.8                 # via requests
-importlib-metadata==1.5.0  # via pluggy, tox
+importlib-metadata==1.5.0  # via pluggy, tox, virtualenv
+importlib-resources==1.0.2  # via virtualenv
 packaging==20.1           # via tox
-pathlib2==2.3.5           # via importlib-metadata
+pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
 requests==2.22.0          # via codecov
 scandir==1.10.0           # via pathlib2
-six==1.14.0               # via packaging, pathlib2, tox
+six==1.14.0               # via packaging, pathlib2, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2
-tox==3.14.3
+tox==3.14.4
+typing==3.7.4.1           # via importlib-resources
 urllib3==1.25.8           # via requests
-virtualenv==16.7.9        # via tox
+virtualenv==20.0.3        # via tox
 zipp==1.1.0               # via importlib-metadata

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -5,3 +5,15 @@ Since pytest discourages putting __init__.py into test directory (i.e. making te
 one cannot import from anywhere under tests folder. However, some utility classes/methods might be useful
 in multiple test modules (i.e. factoryboy factories, base test classes). So this package is the place to put them.
 """
+from mock import patch
+
+
+def patch_site_configs(values):
+    """
+    Helper to mock site configuration values.
+
+    :param values dict.
+
+    Use either as `@patch_site_configs(...)` or `with patch_site_configs(...):`.
+    """
+    return patch.dict('openedx.core.djangoapps.site_configuration.helpers.MOCK_SITE_CONFIG_VALUES', values)

--- a/tests/test_acl_backend.py
+++ b/tests/test_acl_backend.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+
+import six
+import pytest
+from test_utils.factories import (
+    UserFactory,
+    CourseAccessGroupFactory,
+    CourseOverviewFactory,
+    MembershipFactory,
+    OrganizationFactory,
+    GroupCourseFactory,
+)
+from organizations.models import OrganizationCourse, UserOrganizationMapping
+from course_access_groups.acl_backends import default_backend
+from test_utils import patch_site_configs
+
+@pytest.mark.django_db
+class TestAclBackend(object):
+    """
+    Tests for the access control backend.
+
+    Testing the integration point with Open edX.
+
+    Platforms' `default_has_access` is always checked via this backend.
+    """
+
+    @pytest.fixture(autouse=True)
+    def init_models(self):
+        """
+        Create test model fixtures.
+        """
+        self.user = UserFactory.create()
+        self.course = CourseOverviewFactory.create()
+
+    @pytest.mark.parametrize('default_has_access', [False, True])
+    def test_blocked_by_default(self, default_has_access):
+        """
+        Ensure that a learner without a CAG Group has arbitrary access.
+
+        When the feature is enabled, the platform access rules (default_has_access) are ignored.
+
+        :param default_has_access: Experimenting with different Access Control Backends `default_has_access` parameter.
+        :return:
+        """
+        assert not default_backend(self.user, self.course, default_has_access, {})
+
+    @pytest.mark.parametrize('default_has_access', [False, True])
+    def test_disabled_feature(self, default_has_access):
+        """
+        When the feature is disabled, the platform access rules (default_has_access) are applied.
+
+        :param default_has_access: Experimenting with different Access Control Backends `default_has_access` parameter.
+        """
+        with patch_site_configs({'ENABLE_COURSE_ACCESS_GROUPS': False}):
+            assert default_backend(self.user, self.course, default_has_access, {}) == default_has_access
+
+    @pytest.mark.parametrize('default_has_access', [False, True])
+    def test_admins_have_access(self, default_has_access):
+        """
+        Staff and Superusers access is controlled by the platform `default_has_access`.
+        """
+        staff = UserFactory.create(is_staff=True)
+        superuser = UserFactory.create(is_superuser=True)
+        assert default_backend(staff, self.course, default_has_access, {}) == default_has_access
+        assert default_backend(superuser, self.course, default_has_access, {}) == default_has_access
+
+    @pytest.mark.parametrize('default_has_access', [False, True])
+    def test_org_admins_have_access(self, default_has_access):
+        """
+        Organization-wide admins have access to all org courses.
+        """
+        user = UserFactory.create()
+        organization=OrganizationFactory.create()
+        OrganizationCourse.objects.create(course_id=six.text_type(self.course.id), organization=organization)
+        UserOrganizationMapping.objects.create(
+            user=user,
+            organization=organization,
+            is_amc_admin=True,
+        )
+        assert default_backend(user, self.course, default_has_access, {}) == default_has_access
+
+    @pytest.mark.parametrize('default_has_access', [False, True])
+    def test_allow_members(self, default_has_access):
+        """
+        Members have access to courses.
+
+        Via the `Membership` whether it's automatic via `MembershipRule` or manually assigned.
+        """
+        group = CourseAccessGroupFactory.create()
+        GroupCourseFactory.create(course=self.course, group=group)
+        MembershipFactory.create(user=self.user, group=group)
+        assert default_backend(self.user, self.course, default_has_access, {}) == default_has_access

--- a/tests/test_acl_backend.py
+++ b/tests/test_acl_backend.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+"""
+Testing the Access Control Backend `acl_backend.user_has_access`.
+"""
 
 from __future__ import absolute_import, unicode_literals
 
@@ -13,8 +16,9 @@ from test_utils.factories import (
     GroupCourseFactory,
 )
 from organizations.models import OrganizationCourse, UserOrganizationMapping
-from course_access_groups.acl_backends import default_backend
+from course_access_groups.acl_backends import user_has_access
 from test_utils import patch_site_configs
+
 
 @pytest.mark.django_db
 class TestAclBackend(object):
@@ -27,7 +31,7 @@ class TestAclBackend(object):
     """
 
     @pytest.fixture(autouse=True)
-    def init_models(self):
+    def setup(self):
         """
         Create test model fixtures.
         """
@@ -44,7 +48,7 @@ class TestAclBackend(object):
         :param default_has_access: Experimenting with different Access Control Backends `default_has_access` parameter.
         :return:
         """
-        assert not default_backend(self.user, self.course, default_has_access, {})
+        assert not user_has_access(self.user, self.course, default_has_access, {})
 
     @pytest.mark.parametrize('default_has_access', [False, True])
     def test_disabled_feature(self, default_has_access):
@@ -54,17 +58,23 @@ class TestAclBackend(object):
         :param default_has_access: Experimenting with different Access Control Backends `default_has_access` parameter.
         """
         with patch_site_configs({'ENABLE_COURSE_ACCESS_GROUPS': False}):
-            assert default_backend(self.user, self.course, default_has_access, {}) == default_has_access
+            assert user_has_access(self.user, self.course, default_has_access, {}) == default_has_access
 
     @pytest.mark.parametrize('default_has_access', [False, True])
-    def test_admins_have_access(self, default_has_access):
+    def test_site_staff_have_access(self, default_has_access):
         """
-        Staff and Superusers access is controlled by the platform `default_has_access`.
+        Site-wide staff access is controlled by the platform `default_has_access`.
         """
         staff = UserFactory.create(is_staff=True)
+        assert user_has_access(staff, self.course, default_has_access, {}) == default_has_access
+
+    @pytest.mark.parametrize('default_has_access', [False, True])
+    def test_superuser_have_access(self, default_has_access):
+        """
+        Superusers access is controlled by the platform `default_has_access`.
+        """
         superuser = UserFactory.create(is_superuser=True)
-        assert default_backend(staff, self.course, default_has_access, {}) == default_has_access
-        assert default_backend(superuser, self.course, default_has_access, {}) == default_has_access
+        assert user_has_access(superuser, self.course, default_has_access, {}) == default_has_access
 
     @pytest.mark.parametrize('default_has_access', [False, True])
     def test_org_admins_have_access(self, default_has_access):
@@ -72,14 +82,18 @@ class TestAclBackend(object):
         Organization-wide admins have access to all org courses.
         """
         user = UserFactory.create()
-        organization=OrganizationFactory.create()
+        organization = OrganizationFactory.create()
         OrganizationCourse.objects.create(course_id=six.text_type(self.course.id), organization=organization)
         UserOrganizationMapping.objects.create(
             user=user,
             organization=organization,
             is_amc_admin=True,
         )
-        assert default_backend(user, self.course, default_has_access, {}) == default_has_access
+        assert user_has_access(user, self.course, default_has_access, {}) == default_has_access
+
+        # Basic test for `is_organization_staff` to ensure `user.is_active` is respected.
+        inactive = UserFactory.create(is_active=False)
+        assert not user_has_access(inactive, self.course, default_has_access, {})
 
     @pytest.mark.parametrize('default_has_access', [False, True])
     def test_allow_members(self, default_has_access):
@@ -91,4 +105,4 @@ class TestAclBackend(object):
         group = CourseAccessGroupFactory.create()
         GroupCourseFactory.create(course=self.course, group=group)
         MembershipFactory.create(user=self.user, group=group)
-        assert default_backend(self.user, self.course, default_has_access, {}) == default_has_access
+        assert user_has_access(self.user, self.course, default_has_access, {}) == default_has_access

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}-django111,py36-django20,docs,quality,pii_check
+envlist = py27-django111,docs
 
 [doc8]
 max-line-length = 120
@@ -60,19 +60,17 @@ whitelist_externals =
 deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
-    echo "Skipping quality checks for now."
-#    touch tests/__init__.py
-#    pylint course_access_groups tests test_utils manage.py setup.py
-#    pylint --py3k course_access_groups tests test_utils manage.py setup.py
-#    rm tests/__init__.py
-#    pycodestyle course_access_groups tests manage.py setup.py
-#    pydocstyle course_access_groups tests manage.py setup.py
-#    isort --check-only --diff --recursive tests test_utils course_access_groups manage.py setup.py test_settings.py
-#    make selfcheck
+    touch tests/__init__.py
+    pylint course_access_groups tests test_utils manage.py setup.py
+    pylint --py3k course_access_groups tests test_utils manage.py setup.py
+    rm tests/__init__.py
+    pycodestyle course_access_groups tests manage.py setup.py
+    pydocstyle course_access_groups tests manage.py setup.py
+    isort --check-only --diff --recursive tests test_utils course_access_groups manage.py setup.py test_settings.py
+    make selfcheck
 
 [testenv:pii_check]
 deps =
     -r{toxinidir}/requirements/test.txt
 commands =
-    echo "Skipping pii checks for now."
-;    code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage
+    code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage


### PR DESCRIPTION
Make the access control backend work.

### TODO

 - [x] Add feature flags
 - [x] Write string docs
 - [x] Make tests pass


### How to Review?

 - The main work is on the commit labeled `CAG access control backend with feature flag` the rest is prep work.

### Dropping Python 3 Support

This PR drops support for Python 3 because the `edx-organizations` version for Hawthorn has Python 3 compatibility issue so it's no longer possible. The plan is to get back the support for it as soon as Juniper support is needed.

### Jira Issue

 - [**RED-724:** Create an API for Course Access Groups 2/3: Finish all gluing work](https://appsembler.atlassian.net/browse/RED-724)