### PR TITLE
API permissions and multisite separation

### DIFF
--- a/course_access_groups/serializers.py
+++ b/course_access_groups/serializers.py
@@ -2,9 +2,14 @@
 
 from __future__ import absolute_import, unicode_literals
 
+from six import text_type
+from django.contrib.auth import get_user_model
+
+from organizations.models import UserOrganizationMapping, OrganizationCourse
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from course_access_groups.models import (
     CourseAccessGroup,
@@ -12,6 +17,7 @@ from course_access_groups.models import (
     Membership,
     MembershipRule,
 )
+from course_access_groups.permissions import get_current_organization
 
 
 class CourseKeyField(serializers.RelatedField):
@@ -37,12 +43,10 @@ class CourseKeyField(serializers.RelatedField):
 
 
 class CourseAccessGroupSerializer(serializers.ModelSerializer):
-    organization_name = serializers.CharField(source='organization.name', read_only=True)
-
     class Meta:
         model = CourseAccessGroup
         fields = [
-            'id', 'name', 'description', 'organization', 'organization_name',
+            'id', 'name', 'description',
         ]
 
 

--- a/course_access_groups/views.py
+++ b/course_access_groups/views.py
@@ -43,7 +43,10 @@ class MembershipViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     serializer_class = MembershipSerializer
 
     def get_queryset(self):
-        return self.model.objects.all()
+        organization = get_current_organization(self.request)
+        return self.model.objects.filter(
+            group__in=CourseAccessGroup.objects.filter(organization=organization),
+        )
 
 
 class MembershipRuleViewSet(CommonAuthMixin, viewsets.ModelViewSet):

--- a/course_access_groups/views.py
+++ b/course_access_groups/views.py
@@ -52,7 +52,10 @@ class MembershipRuleViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     serializer_class = MembershipRuleSerializer
 
     def get_queryset(self):
-        return self.model.objects.all()
+        organization = get_current_organization(self.request)
+        return self.model.objects.filter(
+            group__in=CourseAccessGroup.objects.filter(organization=organization),
+        )
 
 
 class GroupCourseViewSet(CommonAuthMixin, viewsets.ModelViewSet):

--- a/course_access_groups/views.py
+++ b/course_access_groups/views.py
@@ -67,4 +67,7 @@ class GroupCourseViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     serializer_class = GroupCourseSerializer
 
     def get_queryset(self):
-        return self.model.objects.all()
+        organization = get_current_organization(self.request)
+        return self.model.objects.filter(
+            group__in=CourseAccessGroup.objects.filter(organization=organization),
+        )

--- a/course_access_groups/views.py
+++ b/course_access_groups/views.py
@@ -20,7 +20,7 @@ from course_access_groups.models import (
     MembershipRule,
     GroupCourse,
 )
-from course_access_groups.permissions import CommonAuthMixin
+from course_access_groups.permissions import get_current_organization, CommonAuthMixin
 
 
 class CourseAccessGroupViewSet(CommonAuthMixin, viewsets.ModelViewSet):
@@ -28,8 +28,13 @@ class CourseAccessGroupViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     pagination_class = LimitOffsetPagination
     serializer_class = CourseAccessGroupSerializer
 
+    def perform_create(self, serializer):
+        organization = get_current_organization(self.request)
+        serializer.save(organization=organization)
+
     def get_queryset(self):
-        return self.model.objects.all()
+        organization = get_current_organization(self.request)
+        return self.model.objects.filter(organization=organization)
 
 
 class MembershipViewSet(CommonAuthMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
I've added tests for the API ViewSet classes to ensure multi site separation besides normal permissions:

 - Amended the `get_queryset` for all ViewSet to limit the API to resources within the organization.
 - Added custom serializers (User, CAG and CourseKey) for validation to prevent resource leak between organizations for foreign keys.

### Notes for the Reviewer
 - Review the commits one by one. The first one has most of the ideas, which the other commits copy from.
 - `CourseKeyFieldWithPermission` is weird since it sets the `CourseKey` instead of an actual course, I might want to change that.
 - After putting so many hours, I realized that my testing strategy wasn't really efficient, because I was testing everything (ViewSets and Seializers) in a single integration test, which makes both slow and complicated tests. I might want to do it better in the future by doing more unit tests and less integration tests.

### TODO
 - [x] Fix tests
 - [x] Add tests to ensure the security checks are valid
 - [ ] Split into smaller PRs (if needed by the reviewer)
