### PR TITLE
PublicCourse API ViewSet

### DIFF
--- a/course_access_groups/models.py
+++ b/course_access_groups/models.py
@@ -72,7 +72,7 @@ class Membership(utils_models.TimeStampedModel):
         # Ideally an exception should be thrown if there's more than one organization
         # but such error is out of the scope of the CAG module.
         user_orgs = Organization.objects.filter(
-            pk__in=UserOrganizationMapping.objects.filter(user=user),
+            pk__in=UserOrganizationMapping.objects.filter(user=user, is_active=True),
         )
         rule = MembershipRule.objects.filter(
             domain=email_domain,

--- a/course_access_groups/permissions.py
+++ b/course_access_groups/permissions.py
@@ -87,8 +87,10 @@ def user_has_public_access_to_course(user, course):
     return OrganizationCourse.objects.filter(
         course_id=PublicCourse.objects.filter(course=course).values('course_id'),
         organization_id__in=UserOrganizationMapping.objects.filter(
+            is_active=True,
             user=user,
         ).values('organization_id'),
+        active=True,
     )
 
 

--- a/course_access_groups/serializers.py
+++ b/course_access_groups/serializers.py
@@ -30,7 +30,7 @@ class CourseKeyFieldWithPermission(serializers.RelatedField):
 
     def get_queryset(self):
         organization = get_current_organization(self.context['request'])
-        organization_courses = OrganizationCourse.objects.filter(organization=organization)
+        organization_courses = OrganizationCourse.objects.filter(organization=organization, active=True)
         return CourseOverview.objects.filter(
             id__in=organization_courses.values('course_id'),
         )
@@ -76,6 +76,7 @@ class UserFieldWithPermission(serializers.RelatedField):
         return get_user_model().objects.filter(
             id__in=UserOrganizationMapping.objects.filter(
                 organization=organization,
+                is_active=True,
             ).values('user_id'),
         )
 

--- a/course_access_groups/serializers.py
+++ b/course_access_groups/serializers.py
@@ -16,6 +16,7 @@ from course_access_groups.models import (
     GroupCourse,
     Membership,
     MembershipRule,
+    PublicCourse,
 )
 from course_access_groups.permissions import get_current_organization
 
@@ -149,6 +150,17 @@ class MembershipRuleSerializer(serializers.ModelSerializer):
             'name',
             'domain',
             'group',
+        ]
+
+
+class PublicCourseSerializer(serializers.ModelSerializer):
+    course = CourseKeyFieldWithPermission(source='course_id')
+
+    class Meta:
+        model = PublicCourse
+        fields = [
+            'id',
+            'course',
         ]
 
 

--- a/course_access_groups/urls.py
+++ b/course_access_groups/urls.py
@@ -29,6 +29,12 @@ router.register(
 )
 
 router.register(
+    r'public-courses',
+    views.PublicCourseViewSet,
+    base_name='public-courses',
+)
+
+router.register(
     r'group-courses',
     views.GroupCourseViewSet,
     base_name='group-courses',


### PR DESCRIPTION
Add APIs for the public course feature. Following up on #30.

### Jira
 - [**RED-794:** Support the public course feature](https://appsembler.atlassian.net/browse/RED-794)

### Related Issues
This PR also refactors the module to ensure `is_active` check for both OrganizationCourse and UserOrganizationMapping. Closes #32. I skipped on adding tests because we don't really use those `active` flags. Nevertheless adding them is worthwhile.