### PR TITLE
Read-only /users API with the membership info

### DIFF
--- a/course_access_groups/serializers.py
+++ b/course_access_groups/serializers.py
@@ -165,6 +165,30 @@ class PublicCourseSerializer(serializers.ModelSerializer):
         ]
 
 
+class MembershipSubSerializer(serializers.ModelSerializer):
+    group = CourseAccessGroupFieldWithPermission()
+
+    class Meta:
+        model = Membership
+        fields = [
+            'id',
+            'group',
+        ]
+
+
+class UserSerializer(serializers.ModelSerializer):
+    membership = MembershipSubSerializer(read_only=True)
+
+    class Meta:
+        model = get_user_model()
+        fields = [
+            'id',
+            'username',
+            'email',
+            'membership',
+        ]
+
+
 class GroupCourseSerializer(serializers.ModelSerializer):
     course = CourseKeyFieldWithPermission(source='course_id')
     group = CourseAccessGroupFieldWithPermission()

--- a/course_access_groups/urls.py
+++ b/course_access_groups/urls.py
@@ -35,6 +35,12 @@ router.register(
 )
 
 router.register(
+    r'users',
+    views.UsersViewSet,
+    base_name='users',
+)
+
+router.register(
     r'group-courses',
     views.GroupCourseViewSet,
     base_name='group-courses',

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -271,8 +271,8 @@ To make a course private:
     DELETE /course_access_groups/api/v1/public-courses/10/
 
 
-User Membership in Course Access Groups
----------------------------------------
+Membership in Course Access Groups
+----------------------------------
 
 This endpoint lets us to add and remove users from Course Access Groups.
 
@@ -358,6 +358,57 @@ To delete a membership:
 .. code-block:: bash
 
     DELETE /course_access_groups/api/v1/memberships/5/
+
+
+User-Focused Course Access Group API
+------------------------------------
+
+This API is used to retrieve user information with their Course Access Group
+associations. This API is a read-only API.
+
+This ViewSet is provide only the minimal user information like email and
+username. For more detailed user information or modify the membership
+information other specialised APIs should be used.
+
+List Users
+~~~~~~~~~~
+
+This endpoint returns a paginated list of JSON objects in "results".
+Each object represents a single user membership in a Course Access Group.
+Each membership JSON has a single property ``id`` which can be used to delete
+the membership.
+The membership JSON also has two sub-objects representing a user and a
+Course Access Group.
+
+
+.. code-block:: bash
+
+    GET /course_access_groups/api/v1/users/
+
+    {
+      "count": 50,
+      "next": "http://mydomain.com/course_access_groups/api/v1/users/?limit=20&offset=20",
+      "previous": null,
+      "results": [
+        {
+          "id": 2,
+          "username": "ali",
+          "email": "ali@corp.com",
+          "membership": {
+            "id": 5,
+            "group": {
+              "id": 1,
+              "name": "Employees"
+            }
+          }
+        },
+        {
+          "id": 2,
+          "username": "ali",
+          "email": "ali@corp.com",
+          "membership": null
+        }
+    }
 
 
 Rules for Automatic User Membership

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -13,7 +13,7 @@ from course_access_groups.models import (
     MembershipRule,
     PublicCourse,
 )
-from organizations.models import Organization
+from organizations.models import Organization, UserOrganizationMapping
 
 
 class UserFactory(factory.DjangoModelFactory):
@@ -22,6 +22,9 @@ class UserFactory(factory.DjangoModelFactory):
 
     class Meta(object):
         model = get_user_model()
+
+    class Params(object):
+        organization = None
 
 
 class OrganizationFactory(factory.DjangoModelFactory):
@@ -40,6 +43,24 @@ class OrganizationFactory(factory.DjangoModelFactory):
         if extracted:
             for site in extracted:
                 self.sites.add(site)
+
+
+class UserOrganizationMappingFactory(factory.DjangoModelFactory):
+    class Meta(object):
+        model = UserOrganizationMapping
+
+    user = factory.SubFactory(UserFactory)
+    organization = factory.SubFactory(OrganizationFactory)
+
+    @classmethod
+    def create_for(cls, organization, users):
+        """
+        Associate list of users with a certain organization.
+        """
+        mappings = []
+        for user in users:
+            mappings.append(cls.create(organization=organization, user=user))
+        return mappings
 
 
 class CourseAccessGroupFactory(factory.DjangoModelFactory):


### PR DESCRIPTION
### User CAG API
This a new user API which provides a list of users with their Course Access Group memberships. This a mix between both the [Tahoe User API](https://help.appsembler.com/article/439-tahoe-user-api) and the `/memberships` API. In other words it joins the two APIs.

The new `/users` API is a read-only API.