### PR TITLE
bump to 0.5.0

### DIFF
--- a/course_access_groups/__init__.py
+++ b/course_access_groups/__init__.py
@@ -3,6 +3,6 @@ An Open edX plugin to customize courses access by grouping learners and assignin
 """
 
 
-__version__ = '0.5.dev1'
+__version__ = '0.5.0'
 
 default_app_config = 'course_access_groups.apps.CourseAccessGroupsConfig'


### PR DESCRIPTION
Now that PyPi integration works well: https://pypi.org/project/course-access-groups/0.5.dev1/