### PR TITLE
log exceptions for the USER_ACCOUNT_ACTIVATED signal

### DIFF
--- a/course_access_groups/__init__.py
+++ b/course_access_groups/__init__.py
@@ -3,6 +3,6 @@ An Open edX plugin to customize courses access by grouping learners and assignin
 """
 
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 default_app_config = 'course_access_groups.apps.CourseAccessGroupsConfig'

--- a/course_access_groups/signals.py
+++ b/course_access_groups/signals.py
@@ -3,8 +3,11 @@
 Signals and receivers for Course Access Groups.
 """
 
+import logging
 
 from .models import Membership
+
+log = logging.getLogger(__name__)
 
 
 def on_learner_account_activated(sender, user, **kwargs):
@@ -15,4 +18,9 @@ def on_learner_account_activated(sender, user, **kwargs):
     :param user: The activated learner.
     :param kwargs: Extra keyword args.
     """
-    Membership.create_from_rules(user)
+    try:
+        Membership.create_from_rules(user)
+    except Exception:
+        log.exception('Error receiving USER_ACCOUNT_ACTIVATED signal for user %s pk=%s, is_active=%s, sender=%s',
+                      user.email, user.pk, user.is_active, sender)
+        raise

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,47 @@
+"""
+Tests for signal handlers.
+"""
+
+
+import pytest
+
+from course_access_groups.models import Membership
+from course_access_groups.signals import on_learner_account_activated
+
+from test_utils.factories import (
+    MembershipRuleFactory,
+    UserFactory,
+    UserOrganizationMappingFactory,
+)
+
+
+@pytest.mark.django_db
+def test_working_on_account_activated_signal():
+    """
+    Ensure USER_ACCOUNT_ACTIVATED is processed correctly.
+    """
+    rule = MembershipRuleFactory(domain='example.com')
+    mapping = UserOrganizationMappingFactory.create(
+        user__email='someone@example.com',
+        organization=rule.group.organization,
+    )
+
+    on_learner_account_activated(object(), mapping.user)
+    assert Membership.objects.filter(user=mapping.user).exists(), 'Should create the rule'
+
+
+@pytest.mark.django_db
+def test_failed_on_account_activated_signal(monkeypatch, caplog):
+    """
+    Ensure USER_ACCOUNT_ACTIVATED errors are logged.
+    """
+    monkeypatch.delattr(Membership, 'create_from_rules')  # Act as if the create from rules don't work!
+
+    user = UserFactory.create(email='someone@example.com')
+    MembershipRuleFactory(domain='example.com')
+
+    with pytest.raises(AttributeError):
+        on_learner_account_activated(object(), user)
+    assert 'Error receiving USER_ACCOUNT_ACTIVATED signal for user' in caplog.text
+    assert 'someone@example.com' in caplog.text
+    assert 'AttributeError' in caplog.text


### PR DESCRIPTION
This helps to discover errors in SSO SAML Membership not being created.

Jira: RED-2176

Django unfortunately silently handle exceptions when using `send_robus` without logging the exception until Django 3:

 - [#32261 Log exceptions handled in Signal.send_robust() (fixed)](https://code.djangoproject.com/ticket/32261)