### PR TITLE
add `organization_uuid` parameter for superusers

### DIFF
--- a/course_access_groups/__init__.py
+++ b/course_access_groups/__init__.py
@@ -3,6 +3,6 @@ An Open edX plugin to customize courses access by grouping learners and assignin
 """
 
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 
 default_app_config = 'course_access_groups.apps.CourseAccessGroupsConfig'

--- a/course_access_groups/serializers.py
+++ b/course_access_groups/serializers.py
@@ -10,7 +10,7 @@ from rest_framework.exceptions import ValidationError
 
 from .models import CourseAccessGroup, GroupCourse, Membership, MembershipRule, PublicCourse
 from .openedx_modules import CourseOverview
-from .permissions import get_current_organization
+from .permissions import get_requested_organization
 
 
 class CourseKeyFieldWithPermission(serializers.RelatedField):
@@ -21,7 +21,7 @@ class CourseKeyFieldWithPermission(serializers.RelatedField):
     """
 
     def get_queryset(self):
-        organization = get_current_organization(self.context['request'])
+        organization = get_requested_organization(self.context['request'])
         organization_courses = OrganizationCourse.objects.filter(organization=organization, active=True)
         return CourseOverview.objects.filter(
             id__in=organization_courses.values('course_id'),
@@ -64,7 +64,7 @@ class UserFieldWithPermission(serializers.RelatedField):
     """
 
     def get_queryset(self):
-        organization = get_current_organization(self.context['request'])
+        organization = get_requested_organization(self.context['request'])
         return get_user_model().objects.filter(
             id__in=UserOrganizationMapping.objects.filter(
                 organization=organization,
@@ -92,7 +92,7 @@ class CourseAccessGroupFieldWithPermission(serializers.RelatedField):
     """
 
     def get_queryset(self):
-        organization = get_current_organization(self.context['request'])
+        organization = get_requested_organization(self.context['request'])
         return CourseAccessGroup.objects.filter(
             organization=organization,
         )

--- a/course_access_groups/views.py
+++ b/course_access_groups/views.py
@@ -15,7 +15,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from .filters import CourseOverviewFilter, UserFilter
 from .models import CourseAccessGroup, GroupCourse, Membership, MembershipRule, PublicCourse
 from .openedx_modules import CourseOverview
-from .permissions import CommonAuthMixin, get_current_organization
+from .permissions import CommonAuthMixin, get_requested_organization
 from .serializers import (
     CourseAccessGroupSerializer,
     CourseOverviewSerializer,
@@ -40,11 +40,11 @@ class CourseAccessGroupViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     serializer_class = CourseAccessGroupSerializer
 
     def perform_create(self, serializer):
-        organization = get_current_organization(self.request)
+        organization = get_requested_organization(self.request)
         serializer.save(organization=organization)
 
     def get_queryset(self):
-        organization = get_current_organization(self.request)
+        organization = get_requested_organization(self.request)
         return self.model.objects.filter(organization=organization)
 
 
@@ -73,7 +73,7 @@ class CourseViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
         return super(CourseViewSet, self).get_object()
 
     def get_queryset(self):
-        organization = get_current_organization(self.request)
+        organization = get_requested_organization(self.request)
         return CourseOverview.objects.filter(
             id__in=OrganizationCourse.objects.filter(
                 organization=organization,
@@ -88,7 +88,7 @@ class MembershipViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     serializer_class = MembershipSerializer
 
     def get_queryset(self):
-        organization = get_current_organization(self.request)
+        organization = get_requested_organization(self.request)
         return self.model.objects.filter(
             group__in=CourseAccessGroup.objects.filter(organization=organization),
         )
@@ -100,7 +100,7 @@ class MembershipRuleViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     serializer_class = MembershipRuleSerializer
 
     def get_queryset(self):
-        organization = get_current_organization(self.request)
+        organization = get_requested_organization(self.request)
         return self.model.objects.filter(
             group__in=CourseAccessGroup.objects.filter(organization=organization),
         )
@@ -116,7 +116,7 @@ class PublicCourseViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     serializer_class = PublicCourseSerializer
 
     def get_queryset(self):
-        organization = get_current_organization(self.request)
+        organization = get_requested_organization(self.request)
         course_links = OrganizationCourse.objects.filter(organization=organization, active=True)
 
         return self.model.objects.filter(
@@ -140,7 +140,7 @@ class UserViewSet(CommonAuthMixin, viewsets.ReadOnlyModelViewSet):
     search_fields = ['email', 'username', 'profile__name']
 
     def get_queryset(self):
-        organization = get_current_organization(self.request)
+        organization = get_requested_organization(self.request)
         return self.model.objects.filter(
             pk__in=UserOrganizationMapping.objects.filter(
                 organization=organization,
@@ -156,7 +156,7 @@ class GroupCourseViewSet(CommonAuthMixin, viewsets.ModelViewSet):
     serializer_class = GroupCourseSerializer
 
     def get_queryset(self):
-        organization = get_current_organization(self.request)
+        organization = get_requested_organization(self.request)
         return self.model.objects.filter(
             group__in=CourseAccessGroup.objects.filter(organization=organization),
         )


### PR DESCRIPTION
RED-2634.

All endpoints now support choosing a specific organization on the Tahoe
main site instead of `get_current_organization()`.

Use the new parameter like below:

```
GET /course_access_groups/api/v1/courses/?organization_uuid=14cd5716-5455-11ec-a045
```

Then the API would find the right org based on `Organization.edx_uuid` field.

cc: @melvinsoft @estherjsuh @grozdanowski 

I'm still working on this but I'm mostly done with the main design and implementation draft.


### TODO

 - [x] Add tests
 - [x] Deploy on staging
 - [x] Manual test cases below:
  * ✅ Customer site using customer key: should work. does work.
  * ✅ Customer site using customer key with `organization_uuid`: Should 403. Does 403.
  * ✅ Customer site with another customer's key:  should not work. does not work.
  * ✅ Customer site with superuser key and `organization_uuid`: Should work. Does work.
  * ✅ Main site with superuser key and `organization_uuid`: Should work. Does work.
