### PR TITLE
fix MembershipRule for SSO learners

### DIFF
--- a/course_access_groups/__init__.py
+++ b/course_access_groups/__init__.py
@@ -3,6 +3,6 @@ An Open edX plugin to customize courses access by grouping learners and assignin
 """
 
 
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 
 default_app_config = 'course_access_groups.apps.CourseAccessGroupsConfig'

--- a/course_access_groups/apps.py
+++ b/course_access_groups/apps.py
@@ -3,7 +3,6 @@
 Course Access Groups Django application initialization.
 """
 
-
 from django.apps import AppConfig
 from openedx.core.djangoapps.plugins.constants import PluginSignals, PluginURLs, ProjectType
 
@@ -18,17 +17,23 @@ class CourseAccessGroupsConfig(AppConfig):
     # Configuration for Open edX plugins
     plugin_app = {
         PluginURLs.CONFIG: {
-           ProjectType.LMS: {
-               PluginURLs.NAMESPACE: 'course_access_groups',
-               PluginURLs.REGEX: '^course_access_groups/api/v1/',
-           },
+            ProjectType.LMS: {
+                PluginURLs.NAMESPACE: 'course_access_groups',
+                PluginURLs.REGEX: '^course_access_groups/api/v1/',
+            },
         },
         PluginSignals.CONFIG: {
             ProjectType.LMS: {
-                PluginSignals.RECEIVERS: [{
-                    PluginSignals.RECEIVER_FUNC_NAME: 'on_learner_account_activated',
-                    PluginSignals.SIGNAL_PATH: 'openedx.core.djangoapps.signals.signals.USER_ACCOUNT_ACTIVATED',
-                }],
+                PluginSignals.RECEIVERS: [
+                    {
+                        PluginSignals.RECEIVER_FUNC_NAME: 'on_learner_account_activated',
+                        PluginSignals.SIGNAL_PATH: 'openedx.core.djangoapps.signals.signals.USER_ACCOUNT_ACTIVATED',
+                    },
+                    {
+                        PluginSignals.RECEIVER_FUNC_NAME: 'on_learner_register',
+                        PluginSignals.SIGNAL_PATH: 'openedx.core.djangoapps.user_authn.views.register.REGISTER_USER',
+                    },
+                ],
             }
         },
     }

--- a/course_access_groups/signals.py
+++ b/course_access_groups/signals.py
@@ -24,3 +24,19 @@ def on_learner_account_activated(sender, user, **kwargs):
         log.exception('Error receiving USER_ACCOUNT_ACTIVATED signal for user %s pk=%s, is_active=%s, sender=%s',
                       user.email, user.pk, user.is_active, sender)
         raise
+
+
+def on_learner_register(sender, user, **kwargs):
+    """
+    Receive the `REGISTER_USER` signal to apply MembershipRule.
+
+    :param sender: The sender class.
+    :param user: The activated learner.
+    :param kwargs: Extra keyword args.
+    """
+    try:
+        Membership.create_from_rules(user)
+    except Exception:
+        log.exception('Error receiving REGISTER_USER signal for user %s pk=%s, is_active=%s, sender=%s',
+                      user.email, user.pk, user.is_active, sender)
+        raise

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -6,7 +6,10 @@ Tests for signal handlers.
 import pytest
 
 from course_access_groups.models import Membership
-from course_access_groups.signals import on_learner_account_activated
+from course_access_groups.signals import (
+    on_learner_account_activated,
+    on_learner_register,
+)
 
 from test_utils.factories import (
     MembershipRuleFactory,
@@ -16,9 +19,13 @@ from test_utils.factories import (
 
 
 @pytest.mark.django_db
-def test_working_on_account_activated_signal():
+@pytest.mark.parametrize('receiver_function', [
+    on_learner_account_activated,
+    on_learner_register,
+])
+def test_working_on_account_activated_signal(receiver_function):
     """
-    Ensure USER_ACCOUNT_ACTIVATED is processed correctly.
+    Ensure USER_ACCOUNT_ACTIVATED and REGISTER_USER signals are processed correctly.
     """
     rule = MembershipRuleFactory(domain='example.com')
     mapping = UserOrganizationMappingFactory.create(
@@ -26,22 +33,28 @@ def test_working_on_account_activated_signal():
         organization=rule.group.organization,
     )
 
-    on_learner_account_activated(object(), mapping.user)
+    receiver_function(object(), mapping.user)
     assert Membership.objects.filter(user=mapping.user).exists(), 'Should create the rule'
+
+    receiver_function(object(), mapping.user)  # Should not fail when receiving the signal twice
 
 
 @pytest.mark.django_db
-def test_failed_on_account_activated_signal(monkeypatch, caplog):
+@pytest.mark.parametrize('receiver_function,signal_name', [
+    [on_learner_account_activated, 'USER_ACCOUNT_ACTIVATED'],
+    [on_learner_register, 'REGISTER_USER'],
+])
+def test_failed_on_account_activated_signal(monkeypatch, caplog, receiver_function, signal_name):
     """
-    Ensure USER_ACCOUNT_ACTIVATED errors are logged.
+    Ensure  errors in USER_ACCOUNT_ACTIVATED and REGISTER_USER are logged.
     """
-    monkeypatch.delattr(Membership, 'create_from_rules')  # Act as if the create from rules don't work!
+    monkeypatch.delattr(Membership, 'create_from_rules')  # Act as if create_from_rules() don't work!
 
     user = UserFactory.create(email='someone@example.com')
     MembershipRuleFactory(domain='example.com')
 
     with pytest.raises(AttributeError):
-        on_learner_account_activated(object(), user)
-    assert 'Error receiving USER_ACCOUNT_ACTIVATED signal for user' in caplog.text
+        receiver_function(object(), user)
+    assert 'Error receiving {signal_name} signal for user'.format(signal_name=signal_name) in caplog.text
     assert 'someone@example.com' in caplog.text
     assert 'AttributeError' in caplog.text


### PR DESCRIPTION
RED-2176.

### Changes


 - Listen to REGISTER_USER signal in the LMS
 - `Membership.create_from_rules` will be executed twice for SSO users, added tests to ensure it won't fail due to duplicate signals

### Related Changes

 - Ensure `UserOrganizationMapping` is added before the REGISTER_USER signal is sent in the edx-platform repo: https://github.com/appsembler/edx-platform/pull/1054
