### PR TITLE
Fix False-Positive exception logs in Membership rules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.6.1] - 2023-01-04
+~~~~~~~~~~~~~~~~~~~~
+ * Minor fix for a False-Positive log
+
 [0.6.0] - 2022-08-17
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/course_access_groups/__init__.py
+++ b/course_access_groups/__init__.py
@@ -3,6 +3,6 @@ An Open edX plugin to customize courses access by grouping learners and assignin
 """
 
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 default_app_config = 'course_access_groups.apps.CourseAccessGroupsConfig'

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -61,6 +61,17 @@ def test_register_user_signal_inactive_user(caplog):
 
 
 @pytest.mark.django_db
+def test_register_user_signal_new_user():
+    """
+    Ensure that on_learner_account_activated will not raise Organization.DoesNotExist for any reason
+    """
+    _ = MembershipRuleFactory(domain='example.com')
+    user = UserFactory.create(email='someone@example.com')
+
+    on_learner_account_activated(object(), user)
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('receiver_function,signal_name', [
     [on_learner_account_activated, 'USER_ACCOUNT_ACTIVATED'],
     [on_learner_register, 'REGISTER_USER'],


### PR DESCRIPTION
**Description:** Fix False-Positive exception logs in Membership rules

Both `USER_ACCOUNT_ACTIVATED` and `REGISTER_USER` signals call `Membership.create_from_rules` to create membership rules. The problem is that `USER_ACCOUNT_ACTIVATED` will always fail for newly registered users because the user is not linked to an organization yet, then `REGISTER_USER` will fix the membership issue.

This fix is to avoid logging exceptions for `Organization.DoesNotExist` anymore in `on_learner_account_activated` (which is triggered by `USER_ACCOUNT_ACTIVATED`)

_Why we're keeping the call? why not remove it and rely on `on_learner_register`?_
  _This is just for rare cases where the user is deactivated and then reactivated later by an admin_

**JIRA:** https://appsembler.atlassian.net/browse/RED-3674

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
